### PR TITLE
Prevent useless votes and multiple votes on the same comment

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+hyperloglog = "*"
 
 [dev-packages]
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 marvinbot_karma_plugin
+
+## Rationale:
+This plugins uses a Statistical algorithm to keep track of some states. The algorithm in question is Hyperloglog, it has an accuracy of 99% and a very low memory footprint (5kb maybe?), perfectly acceptable for our use case.
+
+Please refer to the following link for more information aboyt Hyperloglog:
+- http://basho.com/posts/technical/what-in-the-hell-is-hyperloglog/
+- https://en.wikipedia.org/wiki/HyperLogLog

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 marvinbot_karma_plugin
 
 ## Rationale:
-This plugins uses a Statistical algorithm to keep track of some states. The algorithm in question is Hyperloglog, it has an accuracy of 99% and a very low memory footprint (5kb maybe?), perfectly acceptable for our use case.
+This plugin uses a Statistical algorithm to keep track of some states. The
+algorithm in question is Hyperloglog, it has an accuracy of 99% and a very
+low memory footprint (5kb maybe?), perfectly acceptable for our use case.
 
 Please refer to the following link for more information aboyt Hyperloglog:
 - http://basho.com/posts/technical/what-in-the-hell-is-hyperloglog/

--- a/karma_plugin/base.py
+++ b/karma_plugin/base.py
@@ -291,7 +291,7 @@ class KarmaPlugin(Plugin):
         self.hll.add(user_message_fingerprint)
 
         # if the count doesn't change, someone is trying to upvote a single
-        # commen more that once.
+        # comment more that once.
         if len(self.hll) == self.telegram_cardinality:
             self.adapter.bot.sendMessage(chat_id=message.chat_id,
                                          text=DUPLICATE_KARMA)

--- a/karma_plugin/base.py
+++ b/karma_plugin/base.py
@@ -9,6 +9,7 @@ import logging
 import json
 import tabulate
 import re
+import hyperloglog
 
 tabulate.MIN_PADDING = 0
 
@@ -23,6 +24,9 @@ class KarmaPlugin(Plugin):
     def __init__(self):
         super(KarmaPlugin, self).__init__('karma')
         self.config = {}
+
+        self.telegram_cardinality = 0
+        self.hll = hyperloglog.HyperLogLog(0.01)  #1% counting error
 
     def get_default_config(self):
         return {
@@ -266,19 +270,44 @@ class KarmaPlugin(Plugin):
 
     def do_vote(self, update, vote):
         message = update.effective_message
+        reply_message = message.reply_to_message
 
-        if message.from_user.id == message.reply_to_message.from_user.id:
+        if message.from_user.id == reply_message.from_user.id:
             self.adapter.bot.sendMessage(chat_id=message.chat_id,
                                          text=NOT_POSSIBLE)
             return
 
+        if (re.match(UPVOTE_PATTERN, reply_message.text) or
+                re.match(DOWNVOTE_PATTERN, reply_message.text)):
+            self.adapter.bot.sendMessage(chat_id=message.chat_id,
+                                         text=NOT_POSSIBLE)
+            return
+
+        # Also, we don't want a user to upvote a message more thatn once.
+        # For that we'll use a randomized algorithm called Hyperloglog.
+        user_message_fingerprint = "{}-{}".format(reply_message.message_id, message.from_user.id)
+
+        # compute the user-message-fingerprint into the cardinality set
+        self.hll.add(user_message_fingerprint)
+
+        # if the count doesn't change, someone is trying to upvote a single
+        # commen more that once.
+        if len(self.hll) == self.telegram_cardinality:
+            self.adapter.bot.sendMessage(chat_id=message.chat_id,
+                                         text=DUPLICATE_KARMA)
+            return
+
+        # If we hit this line, we should increase the cardinality to mark
+        # this message as computed.
+        self.telegram_cardinality += 1
+
         fields = {
             'chat_id': message.chat_id,
-            'message_text': message.reply_to_message.text,
+            'message_text': reply_message.text,
             'giver_first_name': message.from_user.first_name,
             'giver_user_id': message.from_user.id,
-            'receiver_first_name': message.reply_to_message.from_user.first_name,
-            'receiver_user_id': message.reply_to_message.from_user.id,
+            'receiver_first_name': reply_message.from_user.first_name,
+            'receiver_user_id': reply_message.from_user.id,
             'vote': vote
         }
 

--- a/karma_plugin/templates.py
+++ b/karma_plugin/templates.py
@@ -22,6 +22,8 @@ NO_HATERS = "❌ There are no haters here."
 
 NO_HATED_ONES = "❌ There are no hated ones here."
 
+DUPLICATE_KARMA = "❌ Karma already given for this message."
+
 POSITIVE_KARMA = "+1 karma for {receiver} given by {giver}."
 
 NEGATIVE_KARMA = "-1 karma for {receiver} given by {giver}."

--- a/karma_plugin/templates.py
+++ b/karma_plugin/templates.py
@@ -18,7 +18,7 @@ NO_LOVERS = "❌ There are no lovers here."
 
 NO_LOVED_ONES = "❌ There are no loved ones here."
 
-NO_HATERS = "❌ There are no lovers here."
+NO_HATERS = "❌ There are no haters here."
 
 NO_HATED_ONES = "❌ There are no hated ones here."
 


### PR DESCRIPTION
- The first commit fixes a typo on `templates.py`.
- The second commit add two new features:

Summary:

- Prevent a user from voting on a comment several times. To accomplish
this without saving a bunch of messages id on database a  randomized
algorithm called Hyperloglog was used. Please refer to the following link
for more information:

https://en.wikipedia.org/wiki/HyperLogLog

- Prevent a user from voting on a command used to vote (useless vote).
- Update README.md accordingly