### PR TITLE
Fix chat-message collition

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This plugin uses a Statistical algorithm to keep track of some states. The
 algorithm in question is Hyperloglog, it has an accuracy of 99% and a very
 low memory footprint (5kb maybe?), perfectly acceptable for our use case.
 
-Please refer to the following link for more information aboyt Hyperloglog:
+Please refer to the following link for more information about Hyperloglog:
 - http://basho.com/posts/technical/what-in-the-hell-is-hyperloglog/
 - https://en.wikipedia.org/wiki/HyperLogLog

--- a/karma_plugin/base.py
+++ b/karma_plugin/base.py
@@ -272,10 +272,10 @@ class KarmaPlugin(Plugin):
         message = update.effective_message
         reply_message = message.reply_to_message
 
-        #if message.from_user.id == reply_message.from_user.id:
-        #    self.adapter.bot.sendMessage(chat_id=message.chat_id,
-        #                                 text=NOT_POSSIBLE)
-        #    return
+        if message.from_user.id == reply_message.from_user.id:
+            self.adapter.bot.sendMessage(chat_id=message.chat_id,
+                                         text=NOT_POSSIBLE)
+            return
 
         if (re.match(UPVOTE_PATTERN, reply_message.text) or
                 re.match(DOWNVOTE_PATTERN, reply_message.text)):

--- a/karma_plugin/base.py
+++ b/karma_plugin/base.py
@@ -272,10 +272,10 @@ class KarmaPlugin(Plugin):
         message = update.effective_message
         reply_message = message.reply_to_message
 
-        if message.from_user.id == reply_message.from_user.id:
-            self.adapter.bot.sendMessage(chat_id=message.chat_id,
-                                         text=NOT_POSSIBLE)
-            return
+        #if message.from_user.id == reply_message.from_user.id:
+        #    self.adapter.bot.sendMessage(chat_id=message.chat_id,
+        #                                 text=NOT_POSSIBLE)
+        #    return
 
         if (re.match(UPVOTE_PATTERN, reply_message.text) or
                 re.match(DOWNVOTE_PATTERN, reply_message.text)):
@@ -283,9 +283,9 @@ class KarmaPlugin(Plugin):
                                          text=NOT_POSSIBLE)
             return
 
-        # Also, we don't want a user to upvote a message more thatn once.
+        # Also, we don't want a user to upvote a message more than once.
         # For that we'll use a randomized algorithm called Hyperloglog.
-        user_message_fingerprint = "{}-{}".format(reply_message.message_id, message.from_user.id)
+        user_message_fingerprint = "{}-{}-{}".format(message.chat_id, reply_message.message_id, message.from_user.id)
 
         # compute the user-message-fingerprint into the cardinality set
         self.hll.add(user_message_fingerprint)


### PR DESCRIPTION
message_id is not guaranteed to be unique across chats, thus the chat_id has to be taken into account in order to create a unique user fingerprint.